### PR TITLE
Add optional min length parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ selected result.
 * `loadend` fires when the request for results ends, successfully or not.
 * `toggle` fires when the results element is shown or hidden.
 
+## Optional parameters
+
+* `min-length` set the minimum number of charaters required to make an autocomplete request.
+
 ## Credits
 
 Heavily inspired on [github's autocomplete element](https://github.com/github/auto-complete-element).

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -164,6 +164,10 @@ export default class extends Controller {
       this.resultsTarget.hidden = true
       return
     }
+    if (query.length < this.minLength) {
+      this.resultsTarget.hidden = true
+      return
+    }
 
     if (!this.src) return
 
@@ -207,5 +211,13 @@ export default class extends Controller {
 
   get src() {
     return this.data.get("url")
+  }
+
+  get minLength() {
+    const minLength = this.data.get("min-length")
+    if ( !minLength ) {
+      return 0
+    }
+    return parseInt(minLength, 10)
   }
 }


### PR DESCRIPTION
This adds an optional `min-length` parameter to the autocomplete so user
set a minimum length that the query is required to meet before making a
call to the url for results