### PR TITLE
Use keycode to provide better cross browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/afcapel/stimulus-autocomplete",
   "dependencies": {
+    "keycode": "^2.2.0",
     "lodash.debounce": "^4.0.8",
     "stimulus": "^1.1.0"
   },

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -1,5 +1,6 @@
 import { Controller } from 'stimulus'
 import debounce from 'lodash.debounce'
+import keycode from 'keycode'
 
 export default class extends Controller {
   static targets = [ 'input', 'hidden', 'results' ]
@@ -56,29 +57,29 @@ export default class extends Controller {
   }
 
   onKeydown(event) {
-    switch (event.key) {
-      case 'Escape':
+    switch (keycode(event)) {
+      case 'esc':
         if (!this.resultsTarget.hidden) {
           this.resultsTarget.hidden = true
           event.stopPropagation()
           event.preventDefault()
         }
         break
-      case 'ArrowDown':
+      case 'down':
         {
           const item = this.sibling(true)
           if (item) this.select(item)
           event.preventDefault()
         }
         break
-      case 'ArrowUp':
+      case 'up':
         {
           const item = this.sibling(false)
           if (item) this.select(item)
           event.preventDefault()
         }
         break
-      case 'Tab':
+      case 'tab':
         {
           const selected = this.resultsTarget.querySelector('[aria-selected="true"]')
           if (selected) {
@@ -86,7 +87,7 @@ export default class extends Controller {
           }
         }
         break
-      case 'Enter':
+      case 'enter':
         {
           const selected = this.resultsTarget.querySelector('[aria-selected="true"]')
           if (selected && !this.resultsTarget.hidden) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1589,6 +1589,11 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+keycode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
+  integrity sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=
+
 kind-of@^3.0.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"


### PR DESCRIPTION
As some browsers send the keycode in different event properties this
add keycode to figure our what key was pressed by the user and give a
constant value.