### PR TITLE
<input autofocus=autofocus> receives focus immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ selected result.
 
 * `min-length` set the minimum number of charaters required to make an autocomplete request.
 
+## Optional HTML configuration
+
+* If the `<input>` target has an `autofocus` attribute then the input will be given focus immediately so the user can start typing. This is useful if the `<input>` is dynamically added/morphed into the DOM (say by a "edit" button) and the user expects to start typing immediately.
+
 ## Examples
 
 There's a minimal example in the `examples` directory. To run it:

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -23,6 +23,10 @@ export default class extends Controller {
     this.inputTarget.addEventListener("input", this.onInputChange)
     this.resultsTarget.addEventListener("mousedown", this.onResultsMouseDown)
     this.resultsTarget.addEventListener("click", this.onResultsClick)
+
+    if (typeof this.inputTarget.getAttribute("autofocus") === "string") {
+      this.inputTarget.focus()
+    }
   }
 
   disconnect() {


### PR DESCRIPTION
If the `<input>` target has an `autofocus` attribute then the input will be given focus immediately so the user can start typing. This is useful if the `<input>` is dynamically added/morphed into the DOM (say by a "edit" button) and the user expects to start typing immediately.