### PR TITLE
Keyboard navigation | Focus on selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ Items can be included that are not selectable, such as help text or delimiters u
 If the controller has a `hidden` target, that field will be updated with the value
 of the selected option. Otherwise, the search text field will be updated.
 
+The height of the result list can be limited with CSS, e.g.:
+
+```html
+<ul class="list-group" data-autocomplete-target="results" style="max-height: 10rem; overflow-y: scroll;"></ul>
+```
+
 ## Events
 
 Events on the main element that registered the controller:

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -71,6 +71,7 @@ export default class extends Controller {
     target.setAttribute("aria-selected", "true")
     target.classList.add("active")
     this.inputTarget.setAttribute("aria-activedescendant", target.id)
+    target.scrollIntoView(false)
   }
 
   onKeydown(event) {


### PR DESCRIPTION
In long lists one would probably set a `max-height` and `overflow-y: scroll`, so that the result list does not grow endlessly.

In that scenario, the current behavior allows keyboard navigation, but the selected elements are not moved into the view (you don't see what you are selecting). This PR suggests to scroll the currently selected element into the view.

The result looks like this:

![screengrab-20210118-1516](https://user-images.githubusercontent.com/1394828/104926671-c1714f00-59a0-11eb-93e3-2404acdffb09.gif)
