### PR TITLE
allow more elaborate markup with selective input value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ Events on the optional hidden input:
 
 * `min-length` set the minimum number of charaters required to make an autocomplete request.
 * `submit-on-enter` submit the form after the autocomplete selection via enter keypress.
-* `aria-labeledby` can be used to define which elements' `textContent` will be used as the input label upon selection. That way your option elements can have more elaborate content, i.e.:
+* `data-autocomplete-label` can be used to define the input label upon selection. That way your option elements can have more elaborate markup, i.e.:
 
   ```html
-  <li class="list-group-item" role="option" data-autocomplete-value="1" aria-labeledby="bird-1">
-    <p id="bird-1">Blackbird</p>
+  <li class="list-group-item" role="option" data-autocomplete-value="1" data-autocomplete-label="Blackbird">
+    <p>Blackbird</p>
     <p class="text-muted"><small>That's also the name of an airplane</small></p>
   </li>
   ```

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ Events on the optional hidden input:
 
 * `min-length` set the minimum number of charaters required to make an autocomplete request.
 * `submit-on-enter` submit the form after the autocomplete selection via enter keypress.
+* `aria-labeledby` can be used to define which elements' `textContent` will be used as the input label upon selection. That way your option elements can have more elaborate content, i.e.:
+
+  ```html
+  <li class="list-group-item" role="option" data-autocomplete-value="1" aria-labeledby="bird-1">
+    <p id="bird-1">Blackbird</p>
+    <p class="text-muted"><small>That's also the name of an airplane</small></p>
+  </li>
+  ```
 
 ## Optional HTML configuration
 

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -1,6 +1,18 @@
 import { Controller } from "stimulus"
 import debounce from "lodash.debounce"
 
+const extractTextValue = el => {
+  if (el.hasAttribute("aria-labeledby")) {
+    return el.getAttribute("aria-labeledby").split(" ")
+      .map(id => document.getElementById(id))
+      .filter(el => el !== null)
+      .map(el => el.textContent.trim())
+      .join(" ")
+  } else {
+    return el.textContent.trim()
+  }
+}
+
 export default class extends Controller {
   static targets = ["input", "hidden", "results"]
   static values = {
@@ -136,7 +148,7 @@ export default class extends Controller {
       return
     }
 
-    const textValue = selected.textContent.trim()
+    const textValue = extractTextValue(selected)
     const value = selected.getAttribute("data-autocomplete-value") || textValue
     this.inputTarget.value = textValue
 

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -1,17 +1,10 @@
 import { Controller } from "stimulus"
 import debounce from "lodash.debounce"
 
-const extractTextValue = el => {
-  if (el.hasAttribute("aria-labeledby")) {
-    return el.getAttribute("aria-labeledby").split(" ")
-      .map(id => document.getElementById(id))
-      .filter(el => el !== null)
-      .map(el => el.textContent.trim())
-      .join(" ")
-  } else {
-    return el.textContent.trim()
-  }
-}
+const extractTextValue = el =>
+  el.hasAttribute("data-autocomplete-label")
+    ? el.getAttribute("data-autocomplete-label")
+    : el.textContent.trim()
 
 export default class extends Controller {
   static targets = ["input", "hidden", "results"]


### PR DESCRIPTION
with this patch `aria-labeledby` can be used to define which elements' `textContent` will be used as the input label upon selection. That way your option elements can have more elaborate content, i.e.:

```html
<li class="list-group-item" role="option" data-autocomplete-value="1" aria-labeledby="bird-1">
  <p id="bird-1">Blackbird</p>
  <p class="text-muted"><small>That's also the name of an airplane</small></p>
</li>
```
