### PR TITLE
added missing value in url

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ application.register('autocomplete', Autocomplete)
 To use the autocomplete, you need some markup as this:
 
 ```html
-<div data-controller="autocomplete" data-autocomplete-url="/birds/search">
+<div data-controller="autocomplete" data-autocomplete-url-value="/birds/search">
   <input type="text" data-autocomplete-target="input"/>
   <input type="hidden" name="bird_id" data-autocomplete-target="hidden"/>
   <ul class="list-group" data-autocomplete-target="results"></ul>


### PR DESCRIPTION
Hi 👋,

After following the documentation and the online tutorial from Drifting Ruby, I was unable to get it the autocomplete working. After re-reading the [Stimulus](https://stimulus.hotwire.dev/reference/values) documentation, I've found there's a missing value in the data attribute for the URL.



