### PR TITLE
Additional guides and tutorial added

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,12 @@ Events on the optional hidden input:
 
 * If the `<input>` target has an `autofocus` attribute then the input will be given focus immediately so the user can start typing. This is useful if the `<input>` is dynamically added/morphed into the DOM (say by a "edit" button) and the user expects to start typing immediately.
 
-## Example
+## Examples & Guides
 
-[This repo](https://github.com/afcapel/stimulus-autocomplete-example) contains a minimal example of how
+- [This repo](https://github.com/afcapel/stimulus-autocomplete-example) contains a minimal example of how
 to use the library.
+- [Autocomplete with StimulusJS - Drifting Ruby](https://www.driftingruby.com/episodes/autocomplete-with-stimulusjs)
+- [Search Autocomplete Stimulus](https://itnext.io/search-autocomplete-stimulus-4e941df54d39?sk=a09dbf0e1ca8cd2f544ba34b78f739f0)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ application.register('autocomplete', Autocomplete)
 To use the autocomplete, you need some markup as this:
 
 ```html
-<div data-controller="autocomplete" data-autocomplete-url="/birds/search">
+<div data-controller="autocomplete" data-autocomplete-url-value="/birds/search">
   <input type="text" data-autocomplete-target="input"/>
   <input type="hidden" name="bird_id" data-autocomplete-target="hidden"/>
   <ul class="list-group" data-autocomplete-target="results"></ul>


### PR DESCRIPTION
Hi,

To help users find guides and tutorials of stimulus-autocomplete, I've extended the example with 2 additional resources: 
1. Drifting Ruby episode
2. A new tutorial I wrote yesterday
