### PR TITLE
additional guides added

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Events on the optional hidden input:
 
 * If the `<input>` target has an `autofocus` attribute then the input will be given focus immediately so the user can start typing. This is useful if the `<input>` is dynamically added/morphed into the DOM (say by a "edit" button) and the user expects to start typing immediately.
 
-## Example
+## Examples
 
 - [This repo](https://github.com/afcapel/stimulus-autocomplete-example) contains a minimal example of how
 to use the library.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,11 @@ Events on the optional hidden input:
 
 ## Example
 
-[This repo](https://github.com/afcapel/stimulus-autocomplete-example) contains a minimal example of how
+- [This repo](https://github.com/afcapel/stimulus-autocomplete-example) contains a minimal example of how
 to use the library.
+- [Autocomplete with StimulusJS - Drifting Ruby](https://www.driftingruby.com/episodes/autocomplete-with-stimulusjs)
+- [Search Autocomplete Stimulus](https://itnext.io/search-autocomplete-stimulus-4e941df54d39?sk=a09dbf0e1ca8cd2f544ba34b78f739f0)
+
 
 ## Credits
 


### PR DESCRIPTION

Hi,

To help users find guides and tutorials of stimulus-autocomplete, I've extended the example with 2 additional resources:
1. Drifting Ruby episode
2. A new tutorial I wrote yesterday