### PR TITLE
Turn off scrollIntoView(false) by default.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stimulus-autocomplete",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.4",
   "description": "StimulusJS autocomplete component",
   "main": "dist/stimulus-autocomplete.js",
   "source": "src/index.mjs",

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -4,9 +4,10 @@ import debounce from "lodash.debounce"
 export default class extends Controller {
   static targets = ["input", "hidden", "results"]
   static values = {
-    submitOnEnter: Boolean,
     url: String,
-    minLength: Number
+    minLength: Number,
+    submitOnEnter: Boolean,
+    scrollIntoViewAlignToTop: Boolean
   }
 
   connect() {
@@ -73,7 +74,9 @@ export default class extends Controller {
     target.setAttribute("aria-selected", "true")
     target.classList.add("active")
     this.inputTarget.setAttribute("aria-activedescendant", target.id)
-    target.scrollIntoView(false)
+    if (this.hasScrollIntoViewAlignToTopValue) {
+      target.scrollIntoView(this.scrollIntoViewAlignToTopValue)
+    }
   }
 
   onKeydown(event) {


### PR DESCRIPTION
Opt in with `data-autocomplete-scroll-into-view-align-to-top-value="false"` or `data-autocomplete-scroll-into-view-align-to-top-value="true"`

See https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView

Personally, I don't like the behaviour of scrollIntoView(false) and don't want it on by default for all autocomplete dropdowns.

Perhaps we can find something nicer in future? Or options?

Available as `stimulus-autocomplete@2.0.1-rc.4`

@phylor you ok with this? re #46 