### PR TITLE
Enabling Transitions: always dispatch the toggle event

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Events on the optional hidden input:
 
 ## Optional parameters
 
-* `min-length` set the minimum number of charaters required to make an autocomplete request.
+* `min-length` set the minimum number of characters required to make an autocomplete request.
 * `submit-on-enter` submit the form after the autocomplete selection via enter keypress.
+* `skip-hidden-property` skip setting the `hidden` property on the element so that you can manually hide and show the element (by listening to the `toggle` event).
 * `data-autocomplete-label` can be used to define the input label upon selection. That way your option elements can have more elaborate markup, i.e.:
 
   ```html

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -6,7 +6,14 @@ export default class extends Controller {
   static values = {
     submitOnEnter: Boolean,
     url: String,
-    minLength: Number
+    minLength: Number,
+    /*
+     * Should we skip adding/removing the "hidden" property from resultsTarget?
+     *
+     * If set, you must listen to the "toggle" event from this
+     * controller to manually show/hide the results target.
+     */
+    skipHiddenProperty: Boolean,
   }
 
   connect() {
@@ -235,7 +242,9 @@ export default class extends Controller {
 
   open() {
     if (!this.isHidden) return
-    this.resultsTarget.hidden = false
+    if (!this.hasSkipHiddenPropertyValue) {
+      this.resultsTarget.hidden = false
+    }
     this.isHidden = false;
     this.element.setAttribute("aria-expanded", "true")
     this.element.dispatchEvent(
@@ -247,7 +256,9 @@ export default class extends Controller {
 
   close() {
     if (this.isHidden) return
-    this.resultsTarget.hidden = true
+    if (!this.hasSkipHiddenPropertyValue) {
+      this.resultsTarget.hidden = true
+    }
     this.isHidden = true;
     this.inputTarget.removeAttribute("aria-activedescendant")
     this.element.setAttribute("aria-expanded", "false")

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -10,7 +10,7 @@ export default class extends Controller {
   }
 
   connect() {
-    this.resultsTarget.hidden = true
+    this.close();
 
     this.inputTarget.setAttribute("autocomplete", "off")
     this.inputTarget.setAttribute("spellcheck", "false")
@@ -127,7 +127,7 @@ export default class extends Controller {
 
   onInputBlur() {
     if (this.mouseDown) return
-    this.resultsTarget.hidden = true
+    this.close();
   }
 
   commit(selected) {
@@ -135,7 +135,7 @@ export default class extends Controller {
 
     if (selected instanceof HTMLAnchorElement) {
       selected.click()
-      this.resultsTarget.hidden = true
+      this.close();
       return
     }
 
@@ -192,7 +192,7 @@ export default class extends Controller {
   }
 
   hideAndRemoveOptions() {
-    this.resultsTarget.hidden = true
+    this.close();
     this.resultsTarget.innerHTML = null
   }
 
@@ -219,7 +219,11 @@ export default class extends Controller {
         this.resultsTarget.innerHTML = html
         this.identifyOptions()
         const hasResults = !!this.resultsTarget.querySelector('[role="option"]')
-        this.resultsTarget.hidden = !hasResults
+        if (hasResults) {
+          this.open();
+        } else {
+          this.close();
+        }
         this.element.dispatchEvent(new CustomEvent("load"))
         this.element.dispatchEvent(new CustomEvent("loadend"))
       })
@@ -235,7 +239,7 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "true")
     this.element.dispatchEvent(
       new CustomEvent("toggle", {
-        detail: { input: this.input, results: this.results }
+        detail: { action: 'open', input: this.input, results: this.results }
       })
     )
   }
@@ -247,7 +251,7 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "false")
     this.element.dispatchEvent(
       new CustomEvent("toggle", {
-        detail: { input: this.input, results: this.results }
+        detail: { action: 'close', input: this.input, results: this.results }
       })
     )
   }

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -249,7 +249,7 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "true")
     this.element.dispatchEvent(
       new CustomEvent("toggle", {
-        detail: { action: 'open', input: this.input, results: this.results }
+        detail: { action: 'open', inputTarget: this.inputTarget, resultsTarget: this.resultsTarget }
       })
     )
   }
@@ -264,7 +264,7 @@ export default class extends Controller {
     this.element.setAttribute("aria-expanded", "false")
     this.element.dispatchEvent(
       new CustomEvent("toggle", {
-        detail: { action: 'close', input: this.input, results: this.results }
+        detail: { action: 'close', inputTarget: this.inputTarget, resultsTarget: this.resultsTarget }
       })
     )
   }

--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -79,7 +79,7 @@ export default class extends Controller {
   onKeydown(event) {
     switch (event.key) {
       case "Escape":
-        if (!this.resultsTarget.hidden) {
+        if (!this.isHidden) {
           this.hideAndRemoveOptions()
           event.stopPropagation()
           event.preventDefault()
@@ -114,7 +114,7 @@ export default class extends Controller {
           const selected = this.resultsTarget.querySelector(
             '[aria-selected="true"]'
           )
-          if (selected && !this.resultsTarget.hidden) {
+          if (selected && !this.isHidden) {
             this.commit(selected)
             if (!this.hasSubmitOnEnterValue) {
               event.preventDefault()
@@ -234,8 +234,9 @@ export default class extends Controller {
   }
 
   open() {
-    if (!this.resultsTarget.hidden) return
+    if (!this.isHidden) return
     this.resultsTarget.hidden = false
+    this.isHidden = false;
     this.element.setAttribute("aria-expanded", "true")
     this.element.dispatchEvent(
       new CustomEvent("toggle", {
@@ -245,8 +246,9 @@ export default class extends Controller {
   }
 
   close() {
-    if (this.resultsTarget.hidden) return
+    if (this.isHidden) return
     this.resultsTarget.hidden = true
+    this.isHidden = true;
     this.inputTarget.removeAttribute("aria-activedescendant")
     this.element.setAttribute("aria-expanded", "false")
     this.element.dispatchEvent(


### PR DESCRIPTION
Hi!

This closes #59.

I've created 3 clean commits to show the incremental progress -  I have tried to change as little as possible:

1) The controller already has `open()` and `close()` methods, but they were not consistently called. The first commit *always* calls these methods when opening or closing the element. This means that the `toggle` event is now dispatched in open/close situations when it wasn't before, but I think this is a bug fix :). The docs state that the `toggle` event  "fires when the results element is shown or hidden".  I also added a new `action` key to the event set to `open` or `close` so that a listener can determine what's happening.

2) Added a `this.isHidden` property to the controller to track the "is hidden" state, instead of relying on `this.resultsTarget.hidden`.

3) Added a new `skipHiddenProperty` value that can be set if you want to *avoid* `this.resultsTarget.hidden` from being set (because you want to handle hiding/showing yourself).

The end result of this is that a user can now leverage [use-transition](https://stimulus-use.github.io/stimulus-use/#/use-transition) to add, for example, a fade-in/out for this auto-complete. I'll include that example code below in case anyone is interested :).

Thanks!

----------------------------

### Transitions with stimulus-use

A) The HTML:

```html
<div
    data-controller="autocomplete autocomplete-transition"
    data-autocomplete-url-value="/some/url"
    data-autocomplete-skip-hidden-property-value="1"
    data-action="toggle->autocomplete-transition#toggle"
>
    <input data-autocomplete-target="input">

    <div
        data-autocomplete-target="results"
        data-autocomplete-transition-target="results">
    </div>
</div>
```

B) Custom autocomplete-transition controller:

```js
import { Controller } from 'stimulus';
import { useTransition } from 'stimulus-use';

export default class extends Controller {
    static targets = ['results'];

    connect() {
        useTransition(this, {
            element: this.resultsTarget,
            enterActive: 'fade-enter-active',
            enterFrom: 'fade-enter-from',
            enterTo: 'fade-enter-to',
            leaveActive: 'fade-leave-active',
            leaveFrom: 'fade-leave-from',
            leaveTo: 'fade-leave-to',
            hiddenClass: 'd-none',
        });
    }

    toggle(event) {
        if (event.detail.action === 'open') {
            this.enter();
        } else {
            this.leave();
        }
    }
}
```

C) Some fade out / fade in CSS

```css
.fade-enter-active, .fade-leave-active {
    transition: opacity 2000ms;
}
.fade-enter-from, .fade-leave-to {
    opacity: 0;
}
.fade-enter-to, .fade-leave-from {
    opacity: 1;
}
```