### PR TITLE
Allow headers to be configurable

### DIFF
--- a/src/autocomplete.mjs
+++ b/src/autocomplete.mjs
@@ -196,6 +196,10 @@ export default class extends Controller {
     this.resultsTarget.innerHTML = null
   }
 
+  headersForFetch() {
+    return { "X-Requested-With": "XMLHttpRequest" }
+  }
+
   fetchResults() {
     const query = this.inputTarget.value.trim()
     if (!query || query.length < this.minLengthValue) {
@@ -205,7 +209,7 @@ export default class extends Controller {
 
     if (!this.hasUrlValue) return
 
-    const headers = { "X-Requested-With": "XMLHttpRequest" }
+    const headers = this.headersForFetch()
     const url = new URL(this.urlValue, window.location.href)
     const params = new URLSearchParams(url.search.slice(1))
     params.append("q", query)


### PR DESCRIPTION
Hi!

I was running into an issue where I had to update the request headers using `fetch`. That's why I've refactored the headers definition into a method which can be overwritten by an extended controller, like so:

```js
import { Autocomplete } from "stimulus-autocomplete"

export default class extends Autocomplete {
  headersForFetch() {
    return {
      "X-Requested-With": "XMLHttpRequest",
      "Authorization": "Bearer " + myToken
    }
  }
}
```

Let me know if you think this is useful idea and/or if it needs changes!

Thanks :)