### PR TITLE
Add selected option to autocomplete.change event detail

### DIFF
--- a/cypress/integration/autocomplete_spec.js
+++ b/cypress/integration/autocomplete_spec.js
@@ -1,7 +1,4 @@
 describe("Stimulus autocomplete", () => {
-  beforeEach(() =>{
-  })
-
   it("shows results", () => {
     cy.loadPage()
     cy.enterTerm("bird")
@@ -64,6 +61,17 @@ describe("Stimulus autocomplete", () => {
     cy.typeEnter()
 
     cy.assertEventEmitted("autocomplete.change")
+  })
+
+  it("can access the selected element in autocomplete.change events", () => {
+    cy.loadPage("/process-change-event.html")
+    cy.get('#color').should('be.empty')
+
+    cy.enterTerm("bird")
+    cy.assertResultsVisible()
+    cy.clickSecondResult()
+
+    cy.get('#color').contains('Selected color blue')
   })
 })
 

--- a/examples/process-change-event.html
+++ b/examples/process-change-event.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Stimulus Autocomplete</title>
+  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
+  <script async src="https://unpkg.com/es-module-shims@1.2.0/dist/es-module-shims.js"></script>
+  <script type="importmap-shim">
+    {
+      "imports": {
+        "@hotwired/stimulus": "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"
+      }
+    }
+  </script>
+
+  <script type="module-shim">
+    import { Application } from '@hotwired/stimulus'
+    import { Autocomplete } from './stimulus-autocomplete.js'
+
+    const application = Application.start()
+    application.register('autocomplete', Autocomplete)
+
+    // You can access the selected element from the autocomplete.change event and
+    // read any extra properties from it
+    document.addEventListener("autocomplete.change", (event) => {
+      const selected = event.detail.selected
+      const selectedColor = selected.dataset.color
+
+      document.getElementById('color').innerHTML = `Selected color ${selectedColor}`
+    })
+  </script>
+
+  <style>
+    .container {
+      max-width: 600px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <h1 class="my-5">Stimulus autocomplete test</h1>
+    <p id="color"></p>
+
+    <div class="mb-3">
+      <label for="birds">Plain text bird names</label>
+      <div data-controller="autocomplete" data-autocomplete-url-value="/results-complex.html">
+        <input name="birds" type="text" class="form-control" data-autocomplete-target="input" placeholder="search a bird" autofocus/>
+        <input type="hidden" name="bird_id" data-autocomplete-target="hidden"/>
+        <ul data-autocomplete-target="results" class="list-group"></ul>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/results-complex.html
+++ b/examples/results-complex.html
@@ -1,12 +1,12 @@
-<li class="list-group-item" role="option" data-autocomplete-value="1" data-autocomplete-label="Blackbird">
+<li class="list-group-item" role="option" data-autocomplete-value="1" data-autocomplete-label="Blackbird" data-color="black">
   Blackbird
   <span class="badge bg-secondary">species of true thrush</span>
 </li>
-<li class="list-group-item" role="option" data-autocomplete-value="2" data-autocomplete-label="Bluebird (Sialia currucoides)">
+<li class="list-group-item" role="option" data-autocomplete-value="2" data-autocomplete-label="Bluebird (Sialia currucoides)" data-color="blue">
   Bluebird
   <span class="badge bg-secondary">insectivorous or omnivorous</span>
 </li>
-<li class="list-group-item" role="option" data-autocomplete-value="3" data-autocomplete-label="Mockingbird">
+<li class="list-group-item" role="option" data-autocomplete-value="3" data-autocomplete-label="Mockingbird" data-color="multi">
   Mockingbird
   <span class="badge bg-secondary">mimics songs of other birds</span>
 </li>

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -149,7 +149,7 @@ export default class Autocomplete extends Controller {
     this.element.dispatchEvent(
       new CustomEvent("autocomplete.change", {
         bubbles: true,
-        detail: { value: value, textValue: textValue }
+        detail: { value: value, textValue: textValue, selected: selected }
       })
     )
   }


### PR DESCRIPTION
This adds the selected element to `event.detail` in `autocomplete.change` events so it can be used in callbacks.

See `examples/process-change-event.html` for an example:

https://github.com/afcapel/stimulus-autocomplete/blob/0876478f01b3875492f653cb3501790e0e8ec6ab/examples/process-change-event.html#L26-L33

Fixes https://github.com/afcapel/stimulus-autocomplete/issues/86