### PR TITLE
Add support to REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,20 @@ Events on the optional hidden input:
     <p class="text-muted"><small>That's also the name of an airplane</small></p>
   </li>
   ```
+* `data-autocomplete-restAPI` can be used to send a query to a REST API, i.e.:
+
+  ```html
+  <div class="form-group" data-controller="autocomplete" data-autocomplete-url-value="/birds/search" data-autocomplete-restAPI-value=true>
+    ...
+  </div>
+  ```
+* `data-autocomplete-queryParam` can be used to change the query parameter name, i.e.:
+
+  ```html
+  <div class="form-group" data-controller="autocomplete" data-autocomplete-url-value="/birds/search" data-autocomplete-queryParam-value="query">
+    ...
+  </div>
+  ```
 
 ## Optional HTML configuration
 

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -11,6 +11,7 @@ export default class Autocomplete extends Controller {
     ready: Boolean,
     submitOnEnter: Boolean,
     url: String,
+    queryParam: { type: String, default: "q" },
     minLength: Number,
   }
 
@@ -217,7 +218,7 @@ export default class Autocomplete extends Controller {
       return url.toString() + `/${query}`
     } else {
       const params = new URLSearchParams(url.search.slice(1))
-      params.append("q", query)
+      params.append(this.queryParam, query)
       url.search = params.toString()
       return url.toString()
     }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -7,6 +7,7 @@ export default class Autocomplete extends Controller {
   static targets = ["input", "hidden", "results"]
   static classes = ["selected"]
   static values = {
+    restAPI: Boolean,
     ready: Boolean,
     submitOnEnter: Boolean,
     url: String,
@@ -213,8 +214,12 @@ export default class Autocomplete extends Controller {
 
     const url = new URL(this.urlValue, window.location.href)
     const params = new URLSearchParams(url.search.slice(1))
-    params.append("q", query)
-    url.search = params.toString()
+    if (restAPI) {
+      console.log(url.search)
+    } else {
+      params.append("q", query)
+      url.search = params.toString()
+    }
 
     return url.toString()
   }

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -7,7 +7,7 @@ export default class Autocomplete extends Controller {
   static targets = ["input", "hidden", "results"]
   static classes = ["selected"]
   static values = {
-    restAPI: Boolean,
+    restAPI: { type: Boolean, default: false },
     ready: Boolean,
     submitOnEnter: Boolean,
     url: String,

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -213,15 +213,14 @@ export default class Autocomplete extends Controller {
     }
 
     const url = new URL(this.urlValue, window.location.href)
-    const params = new URLSearchParams(url.search.slice(1))
-    if (restAPI) {
-      console.log(url.search)
+    if (this.restAPI) {
+      return url.toString() + `/${query}`
     } else {
+      const params = new URLSearchParams(url.search.slice(1))
       params.append("q", query)
       url.search = params.toString()
+      return url.toString()
     }
-
-    return url.toString()
   }
 
   doFetch = async (url) => {


### PR DESCRIPTION
Added a new value `restAPI` of type Boolean to support REST API format.

This is useful when writing API against the Grape framework, but not only.

Example of API format: `https://some.server.com/api/v1/user/search/John` instead of the current format that appends the query using the following format: `?q=John`