### PR TITLE
Remove unnecesary method call

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -39,7 +39,6 @@ export default class Autocomplete extends Controller {
   disconnect() {
     if (this.hasInputTarget) {
       this.inputTarget.removeEventListener("keydown", this.onKeydown)
-      this.inputTarget.removeEventListener("focus", this.onInputFocus)
       this.inputTarget.removeEventListener("blur", this.onInputBlur)
       this.inputTarget.removeEventListener("input", this.onInputChange)
     }


### PR DESCRIPTION
`this.onInputFocus` was removed in 71d1fc3571201372d1530843741a60ede2926837

Fixes https://github.com/afcapel/stimulus-autocomplete/issues/97