### PR TITLE
Fix id autogeneration for results without id

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,6 +1,6 @@
 const input = "input[name=birds]"
 const hidden = "input[name=bird_id]"
-const optionSelector = "li[role=option]"
+const optionSelector = "li[role=option][id*='-option-']"
 const secondOption = "li[data-autocomplete-value='2']"
 
 Cypress.Commands.add("loadPage", (path = "/") => {
@@ -30,6 +30,8 @@ Cypress.Commands.add("clickSecondResult", () => {
 
 Cypress.Commands.add("assertSecondResultActive", (selectedClass = "active") => {
   cy.get(secondOption).should("have.class", selectedClass)
+  cy.get(secondOption).should("have.attr", "aria-selected")
+  cy.get(input).should("have.attr", "aria-activedescendant").and('match', /stimulus-autocomplete-option-\d+/)
 })
 
 Cypress.Commands.add("assertSecondResultSelected", (textValue = "Bluebird", hiddenValue = 2) => {

--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -13,6 +13,7 @@ export default class Autocomplete extends Controller {
     minLength: Number,
     delay: { type: Number, default: 300 },
   }
+  static uniqOptionId = 0
 
   connect() {
     this.close()
@@ -180,11 +181,9 @@ export default class Autocomplete extends Controller {
   }
 
   identifyOptions() {
-    let id = 0
+    const prefix = this.resultsTarget.id || "stimulus-autocomplete"
     const optionsWithoutId = this.resultsTarget.querySelectorAll(`${optionSelector}:not([id])`)
-    optionsWithoutId.forEach((el) => {
-      el.id = `${this.resultsTarget.id}-option-${id++}`
-    })
+    optionsWithoutId.forEach(el => el.id = `${prefix}-option-${Autocomplete.uniqOptionId++}`)
   }
 
   hideAndRemoveOptions() {


### PR DESCRIPTION
In order to set  set the `aria-activedescendant` attribute in the autocomplete input we need to ensure that every result has a valid dom id. So when the autocomplete loads results from the server, it assigns an id to results that lack one. 

To assign new ids the autocomplete used the results id as prefix. However, if the results had no id, 
the autocomplete was assigning `-option-1`, `-option-2` as ids.

This changes the behaviour to use as a prefix the results id, if present, and fallback to 'stimulus-autocomplete' if not.

We also use a static var to ensure the ids are unique in case there are several autocomplete widgets in the same page.