### PR TITLE
Set scrollIntoView behavior to "auto" to prevent lag when scrolling list

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -71,7 +71,7 @@ export default class Autocomplete extends Controller {
     target.setAttribute("aria-selected", "true")
     target.classList.add(...this.selectedClassesOrDefault)
     this.inputTarget.setAttribute("aria-activedescendant", target.id)
-    target.scrollIntoView({ behavior: "smooth", block: "nearest" })
+    target.scrollIntoView({ behavior: "auto", block: "nearest" })
   }
 
   onKeydown = (event) => {


### PR DESCRIPTION
I've added stimulus-autocomplete in an app with potentially large result sets.  The smooth `scrollIntoView` in that case isn't a good fit.  Your example app is on version 2 of stimulus-autocomplete which doesn't have that behavior.  I have an update for that too I'll fire off a PR for in a moment.

| Smooth | Auto |
---------|------|
![smooth](https://user-images.githubusercontent.com/382216/197876257-6f4e5a48-9bf7-4f02-8e5a-23e0855eb956.gif) | ![auto](https://user-images.githubusercontent.com/382216/197876433-831b0172-e88c-4a5f-ac75-145d9523d5b1.gif)
![smooth_2](https://user-images.githubusercontent.com/382216/197878572-7b4cb01a-849a-4e6e-8518-287523d1001c.gif) | ![auto_2](https://user-images.githubusercontent.com/382216/197878600-d1ce691e-475b-4a92-ac85-bf66dd0f30fe.gif)


