### PR TITLE
Add ability to use local options

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -195,7 +195,7 @@ export default class Autocomplete extends Controller {
   fetchResults = async (query) => {
     try {
       this.element.dispatchEvent(new CustomEvent("loadstart"))
-      const html = await this.hasOptionsValue ? this.fetchLocalOptions(query) : this.fetchRemoteResults(query)
+      const html = await (this.hasOptionsValue ? this.fetchLocalOptions(query) : this.fetchRemoteResults(query))
 
       this.replaceResults(html)
       this.element.dispatchEvent(new CustomEvent("load"))


### PR DESCRIPTION
Hey!

First of all, thank you for this component, it's very useful in my project!
As a follow-up to #116, I added possibility to pass `options` Array, which then can be used in the component.

It also exposes 2 methods:

- `optionMatches` - by default, it does case-insensitive matching, but it can be customised.
- `decorateResult` - which can decorate options with whatever markup is needed in your app.

It allows you to pass not only a plain array, but also an array of objects, with different name and values.

I didn't update the docs, nor did I provide any examples, because first I wanted to get your initial feedback on that.