### PR TITLE
Doublecheck the input length at the last moment

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -10,7 +10,7 @@ export default class Autocomplete extends Controller {
     ready: Boolean,
     submitOnEnter: Boolean,
     url: String,
-    minLength: Number,
+    minLength: { type: Number, default: 1},
     delay: { type: Number, default: 300 },
     queryParam: { type: String, default: "q" },
   }
@@ -188,7 +188,7 @@ export default class Autocomplete extends Controller {
 
   hideAndRemoveOptions() {
     this.close()
-    this.resultsTarget.innerHTML = null
+    this.resultsTarget.innerHTML = ""
   }
 
   fetchResults = async (query) => {
@@ -229,7 +229,13 @@ export default class Autocomplete extends Controller {
   }
 
   replaceResults(html) {
-    this.resultsTarget.innerHTML = html
+    // Double check input length at the last moment to prevent stale results from being shown
+    // should the user delete characters faster than the server responds.
+    if (this.inputTarget.value.length >= this.minLengthValue) {
+      this.resultsTarget.innerHTML = html
+    } else {
+      this.resultsTarget.innerHTML = ""
+    }
     this.identifyOptions()
     if (!!this.options) {
       this.open()


### PR DESCRIPTION
I've had issues where deleting characters in the input field faster than the server is responding to queries can leave old results on screen, even if the entire field is cleared.  It largely occurs when holding the backspace key and releasing either exactly when no characters exist or while the count is < the `minLength`.  The issue is most noticeable if your `data-autocomplete-delay-value` is set very low (mine is 11).

Things that didn't work:
* Add a timestamp in a new data attribute with `Date.now()` and verify the result being rendered is the newest based on when it started rather than was completed in async.  They almost never came in out of order so that wasn't it.
* Remove the debounce entirely. Had no effect.

What did work:
* At the very last moment in `replaceResults(html)` double check the input length and if it's less than `minLengthValue` delete the `innerHTML` instead of replacing it. 

Why it works (AFAIK):
* The input length was only checked before the query is dispatched.  If _while the query was being processed_ the user deleted enough characters to be under the minimum, but before the async stuff finishes it still gets displayed.  You'll notice if watch _really closely_ on the **Before** gif below that the results are removed correctly by `onInputChange` when characters are deleted but redisplayed by the async query when it finishes.


## Example:
* `data-autocomplete-min-length-value="3"`
* `data-autocomplete-delay-value="11"`

| Before | After
--------|-------
![stimulus-autocomplete-main 2023-06-05 16_00_58](https://github.com/afcapel/stimulus-autocomplete/assets/382216/da2c98a1-13bd-4b53-9c5d-e5bf2b3992d7) | ![stimulus-autocomplete-update 2023-06-05 16_02_07](https://github.com/afcapel/stimulus-autocomplete/assets/382216/5e14aa23-74b8-4879-9748-560d1ae819a3)


