### PR TITLE
Respect min-length-value option

### DIFF
--- a/src/autocomplete.js
+++ b/src/autocomplete.js
@@ -173,7 +173,7 @@ export default class Autocomplete extends Controller {
     if (this.hasHiddenTarget) this.hiddenTarget.value = ""
 
     const query = this.inputTarget.value.trim()
-    if (query && query.length >= this.minLengthValue) {
+    if (query.length >= this.minLengthValue) {
       this.fetchResults(query)
     } else {
       this.hideAndRemoveOptions()


### PR DESCRIPTION
When the min length value is set to 0, the autocomplete will not fetch the data from the server. This is a problem when a consumer wants to also show something when the input is empty.

For example, it would unblock the following use case:

```html
<input
  name="search"
  data-autocomplete-target="input"
  data-autocomplete-url-value="/search?q={q}"
  data-autocomplete-min-length-value="0"
  data-action="click->autocomplete#onInputChange"
/>
```

in which some results are shown as soon as the input is focused.

It's a simple way to address the "[fetch on focus](https://github.com/afcapel/stimulus-autocomplete/issues/110)"  issue and an alternative to "[fetch on focus](https://github.com/afcapel/stimulus-autocomplete/pull/121)" PR.